### PR TITLE
fix: update size after revert

### DIFF
--- a/lib/Versions/AbstractS3VersionBackend.php
+++ b/lib/Versions/AbstractS3VersionBackend.php
@@ -48,7 +48,7 @@ abstract class AbstractS3VersionBackend implements IVersionBackend {
 
 	abstract protected function getUrn(FileInfo $file): string;
 
-	abstract protected function postRollback(FileInfo $file);
+	abstract protected function postRollback(FileInfo $file, IVersion $version);
 
 	public function getVersionsForFile(IUser $user, FileInfo $file): array {
 		$s3 = $this->getS3($file);
@@ -68,7 +68,7 @@ abstract class AbstractS3VersionBackend implements IVersionBackend {
 		$s3 = $this->getS3($source);
 		if ($s3) {
 			$this->versionProvider->rollback($s3, $this->getUrn($source), $version->getRevisionId());
-			$this->postRollback($source);
+			$this->postRollback($source, $version);
 			return true;
 		}
 

--- a/lib/Versions/ExternalS3VersionsBackend.php
+++ b/lib/Versions/ExternalS3VersionsBackend.php
@@ -26,6 +26,7 @@ namespace OCA\FilesVersionsS3\Versions;
 use OC\Files\ObjectStore\S3ConnectionTrait;
 use OC\Files\Storage\Wrapper\Jail;
 use OCA\Files_External\Lib\Storage\AmazonS3;
+use OCA\Files_Versions\Versions\IVersion;
 use OCP\Files\FileInfo;
 use OCP\Files\Storage\IStorage;
 
@@ -59,7 +60,7 @@ class ExternalS3VersionsBackend extends AbstractS3VersionBackend {
 		return $path;
 	}
 
-	protected function postRollback(FileInfo $file) {
+	protected function postRollback(FileInfo $file, IVersion $version) {
 		$file->getStorage()->getUpdater()->update($file->getInternalPath());
 	}
 }

--- a/lib/Versions/PrimaryS3VersionsBackend.php
+++ b/lib/Versions/PrimaryS3VersionsBackend.php
@@ -26,6 +26,7 @@ namespace OCA\FilesVersionsS3\Versions;
 use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\ObjectStore\S3;
 use OC\Files\ObjectStore\S3ConnectionTrait;
+use OCA\Files_Versions\Versions\IVersion;
 use OCP\Files\FileInfo;
 use OCP\Files\Storage\IStorage;
 
@@ -62,11 +63,12 @@ class PrimaryS3VersionsBackend extends AbstractS3VersionBackend {
 		return $storage->getURN($file->getId());
 	}
 
-	protected function postRollback(FileInfo $file) {
+	protected function postRollback(FileInfo $file, IVersion $version) {
 		$cache = $file->getStorage()->getCache();
 		$cache->update($file->getId(), [
 			'mtime' => time(),
-			'etag'  => $file->getStorage()->getETag($file->getInternalPath())
+			'etag'  => $file->getStorage()->getETag($file->getInternalPath()),
+			'size'  => $version->getSize(),
 		]);
 	}
 }


### PR DESCRIPTION
Hi ! 

We use s3 as primary storage with this app. And observed that when we revert a file version which has not the same size as the current, downloading is broken.
The download brakes because the file size is not updated in the file cache. So 3 behaviors are possibles :
- reverted version is the same size: works.
- reverted version is bigger:  s3 (MinIO) returns a `206 Partial Content` and the file is corrupted
- reverted version is smaller: the reverse proxy (Nginx) closes the connection early and download fails.

This pull request fixes this by updating the file size in the post rollback.