### PR TITLE
feat: Limit supported NC versions to 29

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,7 +32,7 @@ to prevent versions from taking up an ever increasing amount of space.
 	<repository type="git">https://github.com/nextcloud/files_versions_s3.git</repository>
 
 	<dependencies>
-		<nextcloud min-version="26" max-version="30" />
+		<nextcloud min-version="29" max-version="29" />
 	</dependencies>
 
 	<commands>


### PR DESCRIPTION
Needed after the migration to stableXX for https://github.com/nextcloud/files_versions_s3/pull/41