### PR TITLE
fix: ensure only object versions are returned

### DIFF
--- a/lib/Versions/S3VersionProvider.php
+++ b/lib/Versions/S3VersionProvider.php
@@ -49,6 +49,9 @@ class S3VersionProvider {
 			'Prefix' => $urn,
 		]);
 		$s3versions = array_values($result['Versions'] ?? []);
+		$s3versions = array_filter($s3versions, function (array $version) use ($urn) {
+			return $version['Key'] === $urn;
+		});
 		$versions = array_map(function (array $version) use ($client, $bucket, $urn, $user, $sourceFile, $backend) {
 			$versionId = $version['VersionId'];
 			$lastModified = $version['LastModified'];


### PR DESCRIPTION
Hi !

$s3Version might contain versions of other objects as list in s3 are filtered by prefix. For instance when listing versions of `urn:oid:15`, we would also get versions of `urn:oid:150`.

Thankfully it leads only to errors and not to leaks.